### PR TITLE
[DEV] Update medtracker to dev-b3207ae

### DIFF
--- a/kubernetes/apps/overlays/dev/medtracker/kustomization.yaml
+++ b/kubernetes/apps/overlays/dev/medtracker/kustomization.yaml
@@ -13,7 +13,7 @@ replicas:
 
 images:
   - name: operez11/medtracker
-    newTag: "dev-f9b8130"
+    newTag: "dev-b3207ae"
 
 patchesJson6902:
   - target:


### PR DESCRIPTION
## Dev Image Update

| | |
|---|---|
| **Image** | `operez11/medtracker:dev-b3207ae` |
| **Commit** | [`b3207ae74dba3f4977dad7a24810e722af591e4d`](https://github.com/OPerezSandoval/medtracker/commit/b3207ae74dba3f4977dad7a24810e722af591e4d) |
| **Branch** | `main` |
| **Triggered by** | @OPerezSandoval |

### Changes in this build
change port back to 5000 for container build

---
Ready to merge for dev deployment