### PR TITLE
[DEV] Update medtracker to dev-4c113cc

### DIFF
--- a/kubernetes/apps/overlays/dev/medtracker/kustomization.yaml
+++ b/kubernetes/apps/overlays/dev/medtracker/kustomization.yaml
@@ -13,7 +13,7 @@ replicas:
 
 images:
   - name: operez11/medtracker
-    newTag: "dev-4071cbf"
+    newTag: "dev-4c113cc"
 
 patchesJson6902:
   - target:


### PR DESCRIPTION
## Dev Image Update

| | |
|---|---|
| **Image** | `operez11/medtracker:dev-4c113cc` |
| **Commit** | [`4c113ccd6ede8594f29437f483e8a28f785ee903`](https://github.com/OPerezSandoval/medtracker/commit/4c113ccd6ede8594f29437f483e8a28f785ee903) |
| **Branch** | `main` |
| **Triggered by** | @OPerezSandoval |

### Changes in this build
Merge pull request #6 from OPerezSandoval/feature/add-prod-pipeline

update pipeline

---
Ready to merge for dev deployment