### PR TITLE
[DEV] Update archeflow-site to dev-b316070

### DIFF
--- a/kubernetes/apps/overlays/dev/archeflow-site/kustomization.yaml
+++ b/kubernetes/apps/overlays/dev/archeflow-site/kustomization.yaml
@@ -13,4 +13,4 @@ replicas:
 
 images:
   - name: ghcr.io/operezsandoval/archeflow-site
-    newTag: "dev-latest"
+    newTag: "dev-b316070"


### PR DESCRIPTION
## Dev Image Update

| | |
|---|---|
| **Image** | `ghcr.io/operezsandoval/archeflow-site:dev-b316070` |
| **Commit** | [`b3160703a0127e56a73f69bc3659e94bb8f3c9bb`](https://github.com/OPerezSandoval/archeflow-site/commit/b3160703a0127e56a73f69bc3659e94bb8f3c9bb) |
| **Branch** | `main` |
| **Triggered by** | @OPerezSandoval |

### Changes in this build
Initial Commit - Base site created to test CICD

---
Ready to merge for dev deployment