### PR TITLE
infra: self-manage ArgoCD + add ArgoCD UI ingress

### DIFF
--- a/kubernetes/argocd-bootstrap/argocd-ingress.yaml
+++ b/kubernetes/argocd-bootstrap/argocd-ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argocd-ingress
+  namespace: argo-gitops
+  annotations:
+    # Funnel exposes the ArgoCD UI on the public internet via Tailscale, not
+    # just the tailnet. Matches the other ingresses in this cluster.
+    tailscale.com/funnel: "true"
+spec:
+  ingressClassName: tailscale
+  rules:
+    - host: argocd
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: argocd-server
+                port:
+                  number: 443
+  tls:
+    - hosts:
+        - argocd

--- a/kubernetes/argocd-bootstrap/kustomization.yaml
+++ b/kubernetes/argocd-bootstrap/kustomization.yaml
@@ -11,3 +11,4 @@ namespace: argo-gitops
 resources:
   - https://raw.githubusercontent.com/argoproj/argo-cd/v3.4.2/manifests/install.yaml
   - cluster-admin-binding.yaml
+  - argocd-ingress.yaml

--- a/kubernetes/infra/kustomization.yaml
+++ b/kubernetes/infra/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - argocd
   - cloudflare
   - external-secrets-operator
   - headlamp


### PR DESCRIPTION
Add `argocd` to the infra app-of-apps kustomization so the existing kubernetes/infra/argocd/app.yaml Application is rendered and ArgoCD begins managing its own install (syncs kubernetes/argocd-bootstrap). The Application uses prune:false + ServerSideApply + ignoreDifferences on argocd-cm/rbac-cm/secret, so it adopts the already-running install without risk of pruning or reverting live config.

Add argocd-ingress.yaml to kubernetes/argocd-bootstrap so the ArgoCD UI is exposed via the Tailscale ingress class (host: argocd) and managed as part of the install. Funnel is enabled to match the other ingresses.