### PR TITLE
infra: manage NFS subdir provisioner + default StorageClass in GitOps

### DIFF
--- a/kubernetes/infra/kustomization.yaml
+++ b/kubernetes/infra/kustomization.yaml
@@ -9,5 +9,6 @@ resources:
   - metallb
   - metallb-config
   - metrics-server
+  - nfs-provisioner
   - tailscale
   - vault

--- a/kubernetes/infra/nfs-provisioner/app.yaml
+++ b/kubernetes/infra/nfs-provisioner/app.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nfs-provisioner
+  namespace: argo-gitops
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/OPerezSandoval/homelab-gitops
+    targetRevision: main
+    path: kubernetes/infra/nfs-provisioner/manifests
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: nfs-provisioner
+  syncPolicy:
+    automated:
+      # Storage infra: never let a transient render error prune the
+      # provisioner or StorageClass out from under bound PVs. Manual cleanup only.
+      prune: false
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/kubernetes/infra/nfs-provisioner/kustomization.yaml
+++ b/kubernetes/infra/nfs-provisioner/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - app.yaml

--- a/kubernetes/infra/nfs-provisioner/manifests/configmap.yaml
+++ b/kubernetes/infra/nfs-provisioner/manifests/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nfs-subdir-external-provisioner
+  namespace: nfs-provisioner
+data:
+  # NFS export backing all dynamically-provisioned PVs (the host NAS).
+  NFS_SERVER: "192.168.1.85"
+  NFS_PATH: "/mnt/ssd/k8s"

--- a/kubernetes/infra/nfs-provisioner/manifests/deployment.yaml
+++ b/kubernetes/infra/nfs-provisioner/manifests/deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nfs-subdir-external-provisioner
+  namespace: nfs-provisioner
+  labels:
+    app: nfs-subdir-external-provisioner
+spec:
+  replicas: 1
+  # Single leader-elected provisioner; never run two against the same export.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: nfs-subdir-external-provisioner
+  template:
+    metadata:
+      labels:
+        app: nfs-subdir-external-provisioner
+    spec:
+      serviceAccountName: nfs-subdir-external-provisioner
+      containers:
+        - name: nfs-subdir-external-provisioner
+          image: registry.k8s.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2
+          volumeMounts:
+            - name: nfs-client-root
+              mountPath: /persistentvolumes
+          env:
+            # Must match the StorageClass `provisioner` and the
+            # pv.kubernetes.io/provisioned-by on existing PVs. Do not change.
+            - name: PROVISIONER_NAME
+              value: pavillion-server/nfs
+            - name: NFS_SERVER
+              valueFrom:
+                configMapKeyRef:
+                  name: nfs-subdir-external-provisioner
+                  key: NFS_SERVER
+            - name: NFS_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: nfs-subdir-external-provisioner
+                  key: NFS_PATH
+      volumes:
+        - name: nfs-client-root
+          nfs:
+            server: 192.168.1.85
+            path: /mnt/ssd/k8s

--- a/kubernetes/infra/nfs-provisioner/manifests/kustomization.yaml
+++ b/kubernetes/infra/nfs-provisioner/manifests/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - rbac.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - storageclass.yaml

--- a/kubernetes/infra/nfs-provisioner/manifests/namespace.yaml
+++ b/kubernetes/infra/nfs-provisioner/manifests/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nfs-provisioner

--- a/kubernetes/infra/nfs-provisioner/manifests/rbac.yaml
+++ b/kubernetes/infra/nfs-provisioner/manifests/rbac.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nfs-subdir-external-provisioner
+  namespace: nfs-provisioner
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nfs-subdir-external-provisioner-runner
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: run-nfs-subdir-external-provisioner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nfs-subdir-external-provisioner-runner
+subjects:
+  - kind: ServiceAccount
+    name: nfs-subdir-external-provisioner
+    namespace: nfs-provisioner

--- a/kubernetes/infra/nfs-provisioner/manifests/storageclass.yaml
+++ b/kubernetes/infra/nfs-provisioner/manifests/storageclass.yaml
@@ -1,0 +1,13 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: nfs-storage
+  annotations:
+    # Default SC so PVCs that omit storageClassName (e.g. the Vault helm
+    # chart's volumeClaimTemplate) bind here instead of staying Pending.
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: pavillion-server/nfs
+parameters:
+  archiveOnDelete: "false"
+reclaimPolicy: Retain
+volumeBindingMode: Immediate


### PR DESCRIPTION
The nfs-subdir-external-provisioner and its nfs-storage StorageClass were applied by hand and never tracked in Git, so a cluster rebuild left every PVC Pending until they were re-applied manually.

Capture them as a new infra Application (raw manifests, not the helm chart, to preserve the existing `pavillion-server/nfs` provisioner name that the 4 live PVs and the StorageClass already reference — switching to the chart would orphan them):

- SA + ClusterRole/Binding, ConfigMap (NFS 192.168.1.85:/mnt/ssd/k8s), Deployment (image v4.0.2), and the nfs-storage StorageClass.
- nfs-storage is marked the default StorageClass. This also fixes Vault: its helm volumeClaimTemplate renders a blank storageClassName, so it needs a default SC to bind instead of staying Pending.
- App uses prune:false so a render error can never delete storage infra out from under bound PVs.

Validated: `kubectl kustomize` builds, and `apply --dry-run=server` adopts the existing live resources cleanly (selector unchanged, no immutable diffs).