### PR TITLE
feat(sso): add Authentik IdP backed by CloudNativePG

### DIFF
--- a/kubernetes/infra/authentik/app.yaml
+++ b/kubernetes/infra/authentik/app.yaml
@@ -1,0 +1,63 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: authentik
+  namespace: argo-gitops
+  annotations:
+    # Sync after cnpg-operator (wave 1) so the Cluster CRD exists before extras apply.
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: default
+  sources:
+    # 1) Authentik itself (server + worker + bundled Redis). Bundled Postgres is
+    #    disabled in favour of a CloudNativePG-managed cluster (see extras/).
+    - repoURL: https://charts.goauthentik.io
+      chart: authentik
+      targetRevision: 2026.5.3
+      helm:
+        valuesObject:
+          global:
+            # Injects AUTHENTIK_SECRET_KEY, AUTHENTIK_POSTGRESQL__PASSWORD,
+            # AUTHENTIK_BOOTSTRAP_PASSWORD, AUTHENTIK_BOOTSTRAP_TOKEN.
+            envFrom:
+              - secretRef:
+                  name: authentik-secrets
+          authentik:
+            # Point at the CNPG read-write service; password comes from envFrom above.
+            postgresql:
+              host: authentik-db-rw
+              name: authentik
+              user: authentik
+              port: 5432
+          # Use the CloudNativePG cluster, not the bundled Bitnami subchart.
+          postgresql:
+            enabled: false
+          # Keep the bundled Redis (cache/broker only) but don't persist it.
+          redis:
+            enabled: true
+            master:
+              persistence:
+                enabled: false
+          server:
+            ingress:
+              enabled: true
+              ingressClassName: tailscale
+              hosts:
+                - auth
+              tls:
+                - hosts:
+                    - auth
+    # 2) CNPG Cluster + ExternalSecrets that aren't part of the Helm chart.
+    - repoURL: https://github.com/OPerezSandoval/homelab-gitops.git
+      targetRevision: main
+      path: kubernetes/infra/authentik/extras
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: authentik
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/kubernetes/infra/authentik/extras/external-secret.yaml
+++ b/kubernetes/infra/authentik/extras/external-secret.yaml
@@ -1,0 +1,63 @@
+# Env secret consumed by the Authentik server/worker via global.envFrom.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: authentik-secrets
+  namespace: authentik
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-backend
+  target:
+    name: authentik-secrets
+    creationPolicy: Owner
+    template:
+      data:
+        AUTHENTIK_SECRET_KEY: "{{ .secret_key }}"
+        AUTHENTIK_POSTGRESQL__PASSWORD: "{{ .postgres_password }}"
+        AUTHENTIK_BOOTSTRAP_PASSWORD: "{{ .bootstrap_password }}"
+        AUTHENTIK_BOOTSTRAP_TOKEN: "{{ .bootstrap_token }}"
+  data:
+    - secretKey: secret_key
+      remoteRef:
+        key: secret/authentik
+        property: secret_key
+    - secretKey: postgres_password
+      remoteRef:
+        key: secret/authentik
+        property: postgres_password
+    - secretKey: bootstrap_password
+      remoteRef:
+        key: secret/authentik
+        property: bootstrap_password
+    - secretKey: bootstrap_token
+      remoteRef:
+        key: secret/authentik
+        property: bootstrap_token
+---
+# basic-auth secret consumed by CloudNativePG initdb for the "authentik" DB owner.
+# Same postgres_password value as above → app and DB agree on the password.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: authentik-db-app
+  namespace: authentik
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-backend
+  target:
+    name: authentik-db-app
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/basic-auth
+      data:
+        username: "authentik"
+        password: "{{ .postgres_password }}"
+  data:
+    - secretKey: postgres_password
+      remoteRef:
+        key: secret/authentik
+        property: postgres_password

--- a/kubernetes/infra/authentik/extras/kustomization.yaml
+++ b/kubernetes/infra/authentik/extras/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - external-secret.yaml
+  - postgres-cluster.yaml

--- a/kubernetes/infra/authentik/extras/postgres-cluster.yaml
+++ b/kubernetes/infra/authentik/extras/postgres-cluster.yaml
@@ -1,0 +1,22 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: authentik-db
+  namespace: authentik
+spec:
+  # Single-node homelab: one instance. Bump to 3 once there are >1 worker nodes.
+  instances: 1
+  primaryUpdateStrategy: unsupervised
+  storage:
+    size: 5Gi
+    # NOTE: nfs-storage is the only StorageClass today. Postgres prefers block/local
+    # storage; migrate to a local-path SC when one is added (production hardening).
+    storageClass: nfs-storage
+  bootstrap:
+    initdb:
+      database: authentik
+      owner: authentik
+      # Use the ESO-synced basic-auth secret so the app user password matches what
+      # Authentik receives via AUTHENTIK_POSTGRESQL__PASSWORD (single source in Vault).
+      secret:
+        name: authentik-db-app

--- a/kubernetes/infra/authentik/kustomization.yaml
+++ b/kubernetes/infra/authentik/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - app.yaml

--- a/kubernetes/infra/cnpg-operator/app.yaml
+++ b/kubernetes/infra/cnpg-operator/app.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cnpg-operator
+  namespace: argo-gitops
+  annotations:
+    # Install the operator (and its CRDs) before any app that declares a Cluster CR.
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+  source:
+    repoURL: https://cloudnative-pg.io/charts
+    chart: cloudnative-pg
+    targetRevision: 0.29.0
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cnpg-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      # CNPG CRDs are large; server-side apply avoids the last-applied annotation size limit.
+      - ServerSideApply=true

--- a/kubernetes/infra/cnpg-operator/kustomization.yaml
+++ b/kubernetes/infra/cnpg-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - app.yaml

--- a/kubernetes/infra/kustomization.yaml
+++ b/kubernetes/infra/kustomization.yaml
@@ -3,7 +3,9 @@ kind: Kustomization
 
 resources:
   - argocd
+  - authentik
   - cloudflare
+  - cnpg-operator
   - external-secrets-operator
   - headlamp
   - metallb


### PR DESCRIPTION
Introduce app-layer SSO/OIDC for the cluster:

- cnpg-operator: CloudNativePG operator (chart 0.29.0 / operator v1.30.0) in cnpg-system, sync-wave 1 so its CRDs exist before consumers.
- authentik: Authentik chart 2026.5.3 (sync-wave 2) with:
  - a CNPG Cluster (authentik-db, single instance) as Postgres; bundled Bitnami Postgres subchart disabled.
  - bundled Redis kept, persistence off (cache/broker only).
  - two ExternalSecrets from Vault secret/authentik: the Authentik env secret (envFrom) and a basic-auth secret CNPG + Authentik both use, so the DB password has a single source of truth in Vault.
  - Tailscale ingress at auth.<tailnet> via the chart ingress block.

Both apps wired into the infra app-of-apps.

Follow-ups (documented, not in this PR):
- Seed Vault secret/authentik before first sync (see PR body).
- CNPG ScheduledBackup needs an object-store target (MinIO/S3).
- Postgres on nfs-storage; move DBs to a local-path SC when added.