### PR TITLE
fix(authentik): ignore ESO-defaulted fields to stop ArgoCD drift

### DIFF
--- a/kubernetes/infra/authentik/app.yaml
+++ b/kubernetes/infra/authentik/app.yaml
@@ -61,3 +61,15 @@ spec:
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
+  ignoreDifferences:
+    # ESO's CRD schema defaults these optional fields server-side; they aren't in
+    # our manifest, so ArgoCD would otherwise report perpetual OutOfSync drift.
+    - group: external-secrets.io
+      kind: ExternalSecret
+      jqPathExpressions:
+        - .spec.data[].remoteRef.conversionStrategy
+        - .spec.data[].remoteRef.decodingStrategy
+        - .spec.data[].remoteRef.metadataPolicy
+        - .spec.target.deletionPolicy
+        - .spec.target.template.engineVersion
+        - .spec.target.template.mergePolicy


### PR DESCRIPTION
The authentik app sat OutOfSync because ESO's CRD schema defaults optional fields onto the ExternalSecrets server-side (conversionStrategy, decodingStrategy, metadataPolicy, target.deletionPolicy, template.engineVersion, template.mergePolicy) that aren't in Git. With selfHeal on, ArgoCD kept re-applying and the apiserver kept re-defaulting, looping forever.

Add ignoreDifferences for those paths so the app reports clean Synced, mirroring how vault/metallb ignore webhook caBundle drift.