### PR TITLE
feat(argocd): Authentik OIDC login + Git-managed argocd-cm/rbac-cm

### DIFF
--- a/kubernetes/argocd-bootstrap/argocd-cm-patch.yaml
+++ b/kubernetes/argocd-bootstrap/argocd-cm-patch.yaml
@@ -1,0 +1,21 @@
+# Strategic-merge patch: adds the server URL + Authentik OIDC config onto the
+# upstream argocd-cm without touching its default resource.customizations.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: argo-gitops
+data:
+  url: https://argocd.balinese-pentatonic.ts.net
+  oidc.config: |
+    name: Authentik
+    issuer: https://auth.balinese-pentatonic.ts.net/application/o/argocd/
+    clientID: AlCRKQ5NNiC9tVy3N2PHtb6jhZUKDXvqJnpJaXEh
+    clientSecret: $argocd-oidc:clientSecret
+    requestedScopes:
+      - openid
+      - profile
+      - email
+    requestedIDTokenClaims:
+      groups:
+        essential: true

--- a/kubernetes/argocd-bootstrap/argocd-rbac-cm-patch.yaml
+++ b/kubernetes/argocd-bootstrap/argocd-rbac-cm-patch.yaml
@@ -1,0 +1,12 @@
+# Strategic-merge patch: maps the Authentik "argocd-admins" group to ArgoCD's
+# built-in admin role. Everyone else (incl. authenticated OIDC users) is readonly.
+# The local `admin` account still works independently of this.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-rbac-cm
+  namespace: argo-gitops
+data:
+  policy.default: role:readonly
+  policy.csv: |
+    g, argocd-admins, role:admin

--- a/kubernetes/argocd-bootstrap/kustomization.yaml
+++ b/kubernetes/argocd-bootstrap/kustomization.yaml
@@ -12,3 +12,16 @@ resources:
   - https://raw.githubusercontent.com/argoproj/argo-cd/v3.4.2/manifests/install.yaml
   - cluster-admin-binding.yaml
   - argocd-ingress.yaml
+  - oidc-external-secret.yaml
+
+# Layer cluster-specific config onto the upstream argocd-cm / argocd-rbac-cm.
+# target selectors match by kind+name so namespace rewriting doesn't matter.
+patches:
+  - path: argocd-cm-patch.yaml
+    target:
+      kind: ConfigMap
+      name: argocd-cm
+  - path: argocd-rbac-cm-patch.yaml
+    target:
+      kind: ConfigMap
+      name: argocd-rbac-cm

--- a/kubernetes/argocd-bootstrap/oidc-external-secret.yaml
+++ b/kubernetes/argocd-bootstrap/oidc-external-secret.yaml
@@ -1,0 +1,26 @@
+# OIDC client secret for ArgoCD, synced from Vault (secret/argocd-ak).
+# The part-of=argocd label lets argocd-cm reference it via $argocd-oidc:clientSecret.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: argocd-oidc
+  namespace: argo-gitops
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-backend
+  target:
+    name: argocd-oidc
+    creationPolicy: Owner
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/part-of: argocd
+      data:
+        clientSecret: "{{ .client_secret }}"
+  data:
+    - secretKey: client_secret
+      remoteRef:
+        key: secret/argocd-ak
+        property: client_secret

--- a/kubernetes/infra/argocd/app.yaml
+++ b/kubernetes/infra/argocd/app.yaml
@@ -23,24 +23,12 @@ spec:
       # ServerSideApply avoids "metadata.annotations: Too long" errors common
       # with ArgoCD's CRDs and resources that have many annotations.
       - ServerSideApply=true
-  # Protect live config from being reverted to upstream defaults.
-  # argocd-cm and argocd-rbac-cm hold cluster-specific config (resource
-  # exclusions, ignoreResourceUpdates, RBAC policies, repo creds, etc.)
-  # that we don't yet have captured in Git. Until ticket #15 ports those
-  # into kustomize patches here, ignore the data sections entirely.
-  # argocd-secret holds the admin password hash and TLS material that
-  # rotates outside Git's view.
+  # argocd-cm and argocd-rbac-cm are now managed in Git via kustomize patches in
+  # kubernetes/argocd-bootstrap (url, Authentik OIDC, RBAC policy) — closes the
+  # ticket #15 gap for these two, so they are NO LONGER ignored.
+  # argocd-cmd-params-cm and argocd-secret still hold live-only config (admin
+  # password hash, TLS material) that rotates outside Git's view.
   ignoreDifferences:
-    - group: ""
-      kind: ConfigMap
-      name: argocd-cm
-      jsonPointers:
-        - /data
-    - group: ""
-      kind: ConfigMap
-      name: argocd-rbac-cm
-      jsonPointers:
-        - /data
     - group: ""
       kind: ConfigMap
       name: argocd-cmd-params-cm
@@ -51,6 +39,16 @@ spec:
       name: argocd-secret
       jsonPointers:
         - /data
+    # ESO defaults optional fields on ExternalSecrets server-side (see authentik).
+    - group: external-secrets.io
+      kind: ExternalSecret
+      jqPathExpressions:
+        - .spec.data[].remoteRef.conversionStrategy
+        - .spec.data[].remoteRef.decodingStrategy
+        - .spec.data[].remoteRef.metadataPolicy
+        - .spec.target.deletionPolicy
+        - .spec.target.template.engineVersion
+        - .spec.target.template.mergePolicy
     # Webhook caBundles are populated dynamically by the cluster
     - group: admissionregistration.k8s.io
       kind: MutatingWebhookConfiguration


### PR DESCRIPTION
Wire ArgoCD as the first Authentik OIDC consumer 

argocd-bootstrap:
- argocd-cm-patch: server url + oidc.config (Authentik issuer, clientID, clientSecret via $argocd-oidc ref, openid/profile/email scopes, groups as an essential ID-token claim). Strategic-merge so upstream resource.customizations are preserved.
- argocd-rbac-cm-patch: map Authentik group argocd-admins -> role:admin, default role:readonly. Local admin account unaffected.
- oidc-external-secret: ESO syncs secret/argocd-ak client_secret into a part-of=argocd labelled secret so argocd-cm can reference it.

infra/argocd/app.yaml:
- Stop ignoring /data on argocd-cm and argocd-rbac-cm now that Git manages them (verified live data == upstream defaults, so nothing is lost).
- Keep argocd-cmd-params-cm and argocd-secret /data ignored (live-only).
- Add the ESO server-side-default ignoreDifferences.

Verified: kustomize renders argocd-cm with upstream keys + url + oidc.config.