### PR TITLE
fix(authentik): Funnel the auth ingress so ArgoCD OIDC works

### DIFF
--- a/kubernetes/infra/authentik/app.yaml
+++ b/kubernetes/infra/authentik/app.yaml
@@ -42,6 +42,11 @@ spec:
             ingress:
               enabled: true
               ingressClassName: tailscale
+              annotations:
+                # Funnel so auth.<tailnet> is publicly resolvable with a valid cert,
+                # letting argocd-server reach the OIDC backchannel from in-cluster
+                # (CoreDNS can't resolve tailnet-only MagicDNS names).
+                tailscale.com/funnel: "true"
               hosts:
                 - auth
               tls:


### PR DESCRIPTION
argocd-server (in-cluster, using CoreDNS) can't resolve the tunnel-only MagicDNS name auth.balinese-pentatonic.ts.net, so the OIDC backchannel (.well-known/openid-configuration, token, JWKS) failed with "no such host".

Enable Tailscale Funnel on the Authentik server ingress so the hostname is publicly resolvable with a valid cert; argocd-server (which has internet egress) can then reach the IdP. Login page remains fully auth-gated.